### PR TITLE
fix(auth): handle busy OAuth callback port gracefully

### DIFF
--- a/src/strava_cli/auth.py
+++ b/src/strava_cli/auth.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 import httpx
 
 from strava_cli.config import Config, get_client_credentials, get_config_path
+from strava_cli.exceptions import CallbackServerError
 
 STRAVA_AUTH_URL = "https://www.strava.com/oauth/authorize"
 STRAVA_TOKEN_URL = "https://www.strava.com/oauth/token"
@@ -94,7 +95,10 @@ def start_callback_server(port: int = 8000) -> socketserver.TCPServer:
     OAuthCallbackHandler.state = None
     OAuthCallbackHandler.error = None
 
-    server = socketserver.TCPServer(("localhost", port), OAuthCallbackHandler)
+    try:
+        server = socketserver.TCPServer(("localhost", port), OAuthCallbackHandler)
+    except OSError as e:
+        raise CallbackServerError(port, e.strerror or str(e)) from e
     server.timeout = 120  # 2 minute timeout
 
     return server

--- a/src/strava_cli/commands/auth.py
+++ b/src/strava_cli/commands/auth.py
@@ -52,10 +52,19 @@ def login(
     Opens a browser window for authorization. Requires STRAVA_CLIENT_ID
     and STRAVA_CLIENT_SECRET environment variables.
     """
+    from strava_cli import cli
+    from strava_cli.exceptions import StravaCLIError
+
     scope_list = scopes.split(",") if scopes else None
     config = _load_config()
 
-    result = auth_helpers.interactive_login(scopes=scope_list, port=port, config=config)
+    try:
+        result = auth_helpers.interactive_login(scopes=scope_list, port=port, config=config)
+    except StravaCLIError as e:
+        print(f"error: {e.message}", file=sys.stderr)
+        if e.hint and not cli.state.quiet:
+            print(f"hint: {e.hint}", file=sys.stderr)
+        raise typer.Exit(e.exit_code) from None
 
     if result is None:
         raise typer.Exit(2)

--- a/src/strava_cli/exceptions.py
+++ b/src/strava_cli/exceptions.py
@@ -82,6 +82,25 @@ class MissingCredentialsError(ConfigurationError):
         )
 
 
+class CallbackServerError(StravaCLIError):
+    """Local OAuth callback server could not be started.
+
+    Exit code: 2 (user must free the port or pick another to proceed)
+    """
+
+    exit_code = 2
+
+    def __init__(self, port: int, reason: str) -> None:
+        super().__init__(
+            f"Could not start local callback server on port {port}: {reason}",
+            hint=(
+                f"Port {port} may already be in use. "
+                f"Pick a free one with --port, e.g. 'strava auth login --port 8421'."
+            ),
+        )
+        self.port = port
+
+
 class RateLimitError(StravaCLIError):
     """Strava API rate limit exceeded.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -178,6 +178,29 @@ scopes = ["read"]
         data = json.loads(result.stdout)
         assert "expires_at" in data
 
+    def test_login_port_in_use_fails_gracefully(
+        self,
+        cli_runner: CliRunner,
+        unauthenticated_config: Path,
+        env_credentials: None,
+    ) -> None:
+        """auth login reports a friendly error instead of a traceback when the port is busy."""
+        import socket
+
+        occupied = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        occupied.bind(("localhost", 0))
+        occupied.listen(1)
+        port = occupied.getsockname()[1]
+        try:
+            result = cli_runner.invoke(app, ["auth", "login", "--port", str(port)])
+        finally:
+            occupied.close()
+
+        assert result.exit_code == 2
+        assert "Traceback" not in result.stderr
+        assert f"port {port}" in result.stderr
+        assert "--port" in result.stderr
+
 
 class TestActivities:
     """Tests for activity commands."""


### PR DESCRIPTION
## Human Motivation

This may truly be a tech person / developer thing but still I wanted to improve the experience and avoid huge stack trace erros on the first few CLI commands.


Clanker PR below, cheers!

## Problem

Running `strava auth login` when the callback port (default `8000`) is already in use crashes with a raw Python traceback:

```
OSError: [Errno 48] Address already in use
```

The `socketserver.TCPServer` bind failure propagates uncaught all the way out of the command.

## Fix

- Add `CallbackServerError` (exit code 2) carrying a hint to pick a free port via `--port`.
- `start_callback_server` now catches the `OSError` from the bind and raises `CallbackServerError`.
- The `login` command catches `StravaCLIError` and prints the standard `error:` / `hint:` lines instead of letting the traceback escape.

## Result

```
error: Could not start local callback server on port 8765: Address already in use
hint: Port 8765 may already be in use. Pick a free one with --port, e.g. 'strava auth login --port 8421'.
```

Clean exit code 2, no traceback.

## Tests

Added a Detroit-style test that binds a real socket to a port, then asserts `auth login --port <busy>` exits 2 with the friendly message and no traceback. `make can-release` passes (lint clean, 48 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)